### PR TITLE
feature/update-jekyll-deploy

### DIFF
--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Use GitHub Deploy Action to build and deploy to Github
       # For latest version: `jeffreytse/jekyll-deploy-action@master`
-      - uses: jeffreytse/jekyll-deploy-action@v0.5.0
+      - uses: jeffreytse/jekyll-deploy-action@vmaster
         with:
           provider: 'github'         # Default is github
           token: ${{ secrets.GITHUB_TOKEN }} # It's your Personal Access Token(PAT)


### PR DESCRIPTION
Switches the deploy action to use the latest version found on master instead of 0.5.0. I have no idea why I pinned it to the current version.